### PR TITLE
Adding support for reading the ami variable.

### DIFF
--- a/Packer/PackerV1/src/packer.ts
+++ b/Packer/PackerV1/src/packer.ts
@@ -91,7 +91,7 @@ export function addListeners(tool: EventEmitter) {
     tool.addListener('stdout', _ => extractVariable(_.toString()));
 
     function extractVariable(m: string) {
-        let match = m.match(/(OSDiskUri|OSDiskUriReadOnlySas|TemplateUri|TemplateUriReadOnlySas): (.*)/);
+        let match = m.match(/(OSDiskUri|OSDiskUriReadOnlySas|TemplateUri|TemplateUriReadOnlySas|AMI): (.*)/);
         if (match) {
             tlext.setVariable(match[1], match[2]);
         }


### PR DESCRIPTION
Packer outputs the AMI identifier like AMI: ami-0f21ff048efc11d92.

Therefor it is easy to collect the identifier as well.