### PR TITLE
Adding ManagedImageId and ManagedImageSharedImageGalleryId variables

### DIFF
--- a/Packer/PackerV1/src/packer.ts
+++ b/Packer/PackerV1/src/packer.ts
@@ -91,7 +91,7 @@ export function addListeners(tool: EventEmitter) {
     tool.addListener('stdout', _ => extractVariable(_.toString()));
 
     function extractVariable(m: string) {
-        let match = m.match(/(OSDiskUri|OSDiskUriReadOnlySas|TemplateUri|TemplateUriReadOnlySas|AMI): (.*)/);
+        let match = m.match(/(OSDiskUri|OSDiskUriReadOnlySas|TemplateUri|TemplateUriReadOnlySas|AMI|ManagedImageId|ManagedImageSharedImageGalleryId): (.*)/);
         if (match) {
             tlext.setVariable(match[1], match[2]);
         }

--- a/Packer/PackerV1/task.json
+++ b/Packer/PackerV1/task.json
@@ -158,6 +158,12 @@
         },
         {
             "name": "DeploymentName"
+        },
+        {
+            "name": "ManagedImageId"
+        },
+        {
+            "name": "ManagedImageSharedImageGalleryId"
         }
     ],
     "execution": {


### PR DESCRIPTION
Packer generates output with ManagedImageId and ManagedImageSharedImageGalleryId, which is a resource id in azure. It gives the ability to easily manipulate the managed image in subsequent tasks.