### PR TITLE
Upgrade to Node 10 execution handler

### DIFF
--- a/Packer/PackerV0/package.json
+++ b/Packer/PackerV0/package.json
@@ -29,6 +29,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.1",
     "@types/sinon": "^9.0.0",
+    "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
     "sinon": "^9.0.2",

--- a/Packer/PackerV0/package.json
+++ b/Packer/PackerV0/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "fs": "0.0.1-security",
-    "azure-pipelines-task-lib": "^2.9.3"
+    "azure-pipelines-task-lib": "^3.1.7"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^3.1.0",

--- a/Packer/PackerV0/package.json
+++ b/Packer/PackerV0/package.json
@@ -32,6 +32,6 @@
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
     "sinon": "^9.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^4.0.0"
   }
 }

--- a/Packer/PackerV0/task.json
+++ b/Packer/PackerV0/task.json
@@ -42,11 +42,11 @@
                 "EditableOptions": "True"
             },
             "options": {
-                "build": "build", 
+                "build": "build",
                 "fix": "fix",
                 "inspect": "inspect",
                 "push": "push",
-                "validate": "validate", 
+                "validate": "validate",
                 "version": "version"
             },
             "defaultValue": "build"
@@ -101,7 +101,7 @@
         "name" : "TemplateUriReadOnlySas"
     }],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "src/packer.js",
             "argumentFormat": ""
         }

--- a/Packer/PackerV1/package.json
+++ b/Packer/PackerV1/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "fs": "0.0.1-security",
-    "azure-pipelines-task-lib": "^2.9.3"
+    "azure-pipelines-task-lib": "^3.7.1"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^3.1.0",

--- a/Packer/PackerV1/package.json
+++ b/Packer/PackerV1/package.json
@@ -29,6 +29,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.1",
     "@types/sinon": "^9.0.0",
+    "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
     "memory-streams": "^0.1.3",
     "mocha": "^7.1.1",

--- a/Packer/PackerV1/package.json
+++ b/Packer/PackerV1/package.json
@@ -33,7 +33,7 @@
     "memory-streams": "^0.1.3",
     "mocha": "^7.1.1",
     "sinon": "^9.0.2",
-    "typescript": "^3.8.3",
+    "typescript": "^4.0.0",
     "uuid": "^7.0.3"
   }
 }

--- a/Packer/PackerV1/task.json
+++ b/Packer/PackerV1/task.json
@@ -176,7 +176,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "src/packer.js",
             "argumentFormat": ""
         }


### PR DESCRIPTION
Node execution handler 6 will be deprecated @  March 31st 2022. This pull request updates the package to Node 10 including the necessary dependencies updates.