### PR TITLE
Upgrade to Node 10 execution handler

### DIFF
--- a/PackerTool/task.json
+++ b/PackerTool/task.json
@@ -28,7 +28,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "src/packertool.js",
             "argumentFormat": ""
         }


### PR DESCRIPTION
Fixing error on old node handler

```
##[error]This step requires a node version that does not exist in the agent filesystem. Path: /usr/local/ado-agent/externals/node/bin/node
```